### PR TITLE
Don't look at self when determining whether to execute job

### DIFF
--- a/lib/active_job/plugins/resque/solo/inspector.rb
+++ b/lib/active_job/plugins/resque/solo/inspector.rb
@@ -64,6 +64,9 @@ module ActiveJob
               processing = worker.processing
               next false if processing.blank?
               args = processing["payload"]["args"][0]
+
+              next false if args['job_id'] == job.job_id
+
               job_with_args_eq?(job_class, job_arguments, args)
             end
 


### PR DESCRIPTION
We ran into a situation where our job in the solo queue would fail and enter into some retry logic. Due to the logic in `inspector.rb` the job would skip over the retry because it was determined that the job was already executing. This makes it so the queue will look at jobs not including itself when determining to execute.  