### PR TITLE
Update job_executing? check to handle non-ActiveJob jobs being processed

### DIFF
--- a/lib/active_job/plugins/resque/solo/inspector.rb
+++ b/lib/active_job/plugins/resque/solo/inspector.rb
@@ -66,6 +66,7 @@ module ActiveJob
               next false if processing.blank?
 
               args = processing["payload"]["args"][0]
+              next false if args.blank?
               next false if (@self_enqueueing.nil? || @self_enqueueing) && args['job_id'] == job.job_id
 
               job_with_args_eq?(job_class, job_arguments, args)

--- a/spec/lib/active_job/plugins/resque/solo_spec.rb
+++ b/spec/lib/active_job/plugins/resque/solo_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe ActiveJob::Plugins::Resque::Solo do
       end
     end
 
+    context 'when a non-ActiveJob job is being processed' do
+      let(:enqueued_job) { nil }
+      let(:processing) { {"queue"=>QUEUE, "payload"=>{"class"=>"ResqueJob", "args"=>[]}} }
+
+      it "should appear on the queue" do
+        expect { subject }.to have_enqueued(DefaultTestJob).on_queue(QUEUE)
+      end
+    end
+
     context "when the job is not already enqueued" do
       let(:enqueued_job) { nil }
 
@@ -332,4 +341,3 @@ RSpec.describe ActiveJob::Plugins::Resque::Solo do
     end
   end
 end
-


### PR DESCRIPTION
#### Context 

During the process of migrating jobs that use `Resque` to `ActiveJob`'s `Resque` adapter, it's possible for a worker to be actively processing a job that isn't [serialized by `ActiveJob`](https://github.com/rails/rails/blob/63d3f3f4d868a5ed9eacf00af2a80278aa005051/activejob/lib/active_job/core.rb#L79-L92).

This leads to a `NoMethodError` in the `#job_executing?` check due to [the `args` serialized by `Resque` being empty](https://github.com/resque/resque/blob/7f6b88404dd18698f6f4023e18fdc1ae8318e5e5/lib/resque.rb#L340-L341) (for a job with no arguments).

#### Proposed fix

Add an early return if the `args` are empty, since we wouldn't have a `job_id` to match against and the `args` would otherwise raise errors further down in `#job_with_args_eq?`.